### PR TITLE
Add prefix to custom attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,16 +88,16 @@ android {
     android:layout_margin="4dp"
     android:elevation="2dp"
     android:background="@color/white"
-    app:borderColor="@color/orange_700"
-    app:borderWidth="1dp"
-    app:divider="@color/orange_700"
-    app:dividerPadding="10dp"
-    app:dividerWidth="1dp"
-    app:position="0"
-    app:radius="30dp"
-    app:ripple="true"
-    app:rippleColor="@color/green_800"
-    app:selectedBackground="@color/green_900">
+    app:sbg_borderColor="@color/orange_700"
+    app:sbg_borderWidth="1dp"
+    app:sbg_divider="@color/orange_700"
+    app:sbg_dividerPadding="10dp"
+    app:sbg_dividerWidth="1dp"
+    app:sbg_position="0"
+    app:sbg_radius="30dp"
+    app:sbg_ripple="true"
+    app:sbg_rippleColor="@color/green_800"
+    app:sbg_selectedBackground="@color/green_900">
 
     <com.addisonelliott.segmentedbutton.SegmentedButton
         android:layout_width="0dp"
@@ -105,11 +105,11 @@ android {
         android:layout_weight="1"
         android:fontFamily="@font/aniron"
         android:padding="10dp"
-        app:drawable="@drawable/ic_aragorn"
-        app:drawableGravity="top"
-        app:selectedTextColor="@color/orange_700"
-        app:text="Aragorn"
-        app:textColor="@color/black" />
+        app:sb_drawable="@drawable/ic_aragorn"
+        app:sb_drawableGravity="top"
+        app:sb_selectedTextColor="@color/orange_700"
+        app:sb_text="Aragorn"
+        app:sb_textColor="@color/black" />
 
     <com.addisonelliott.segmentedbutton.SegmentedButton
         android:layout_width="0dp"
@@ -117,11 +117,11 @@ android {
         android:layout_weight="1"
         android:fontFamily="@font/aniron"
         android:padding="10dp"
-        app:drawable="@drawable/ic_gimli"
-        app:drawableGravity="top"
-        app:selectedTextColor="@color/grey_600"
-        app:text="Gimli"
-        app:textColor="@color/black" />
+        app:sb_drawable="@drawable/ic_gimli"
+        app:sb_drawableGravity="top"
+        app:sb_selectedTextColor="@color/grey_600"
+        app:sb_text="Gimli"
+        app:sb_textColor="@color/black" />
 
     <com.addisonelliott.segmentedbutton.SegmentedButton
         android:layout_width="0dp"
@@ -129,11 +129,11 @@ android {
         android:layout_weight="1"
         android:fontFamily="@font/aniron"
         android:padding="10dp"
-        app:drawable="@drawable/ic_legolas"
-        app:drawableGravity="top"
-        app:selectedTextColor="@color/yellow_200"
-        app:text="Legolas"
-        app:textColor="@color/black" />
+        app:sb_drawable="@drawable/ic_legolas"
+        app:sb_drawableGravity="top"
+        app:sb_selectedTextColor="@color/yellow_200"
+        app:sb_text="Legolas"
+        app:sb_textColor="@color/black" />
 </com.addisonelliott.segmentedbutton.SegmentedButtonGroup>
 ```
 
@@ -156,55 +156,55 @@ Check out the [sample project](https://github.com/addisonElliott/SegmentedButton
 
 ### SegmentedButtonGroup
 
-| Attribute                          | Format            | Description                                                                |
-| ---------------------------------- | ----------------- | -------------------------------------------------------------------------- |
-| android:background                 | `drawable\|color` | Set background for every button when unselected (default: transparent)     |
-| app:selectedBackground             | `drawable\|color` | Set background for every button when selected (default: transparent)       |
-| app:borderWidth                    | `dimension`       | Width of border around button group                                        |
-| app:borderColor                    | `color`           | Color of border                                                            |
-| app:borderDashWidth                | `dimension`       | Width of dashes, 0 indicates solid line                                    |
-| app:borderDashGap                  | `dimension`       | Width of gaps in dashes                                                    |
-| app:selectedBorderWidth            | `dimension`       | Width of border around selected button in group                            |
-| app:selectedBorderColor            | `color`           | Color of border for selected button in group                               |
-| app:selectedBorderDashWidth        | `dimension`       | Width of dashes for selected button in group, 0 indicates solid line       |
-| app:selectedBorderDashGap          | `dimension`       | Width of gaps in dashes for selected button in group                       |
-| app:radius                         | `dimension`       | Radius of corners for button group                                         |
-| app:selectedButtonRadius           | `dimension`       | Radius of corners for selected button in group                             |
-| app:position                       | `integer`         | Default button that is selected                                            |
-| app:draggable                      | `boolean`         | Whether or not buttons can be dragged to change selected state             |
-| app:ripple                         | `boolean`         | Whether or not ripple effect is enabled for all buttons                    |
-| app:rippleColor                    | `color`           | Ripple effect tint color for each button                                   |
-| app:divider                        | `drawable\|color` | Drawable or color to display for divider between buttons                   |
-| app:dividerWidth                   | `dimension`       | Width of the divider between buttons, 0 indicates no dividers              |
-| app:dividerRadius                  | `dimension`       | Corner radius for divider to round edges                                   |
-| app:dividerPadding                 | `dimension`       | Divider padding on top and bottom of divider                               |
-| app:selectionAnimationDuration     | `integer`         | Duration in ms for change button selection animation                       |
-| app:selectionAnimationInterpolator | `enum`            | Type of animation used for changing button. Valid options are listed below |
+| Attribute                              | Format            | Description                                                                |
+| ---------------------------------------| ----------------- | -------------------------------------------------------------------------- |
+| android:background                     | `drawable\|color` | Set background for every button when unselected (default: transparent)     |
+| app:sbg_selectedBackground             | `drawable\|color` | Set background for every button when selected (default: transparent)       |
+| app:sbg_borderWidth                    | `dimension`       | Width of border around button group                                        |
+| app:sbg_borderColor                    | `color`           | Color of border                                                            |
+| app:sbg_borderDashWidth                | `dimension`       | Width of dashes, 0 indicates solid line                                    |
+| app:sbg_borderDashGap                  | `dimension`       | Width of gaps in dashes                                                    |
+| app:sbg_selectedBorderWidth            | `dimension`       | Width of border around selected button in group                            |
+| app:sbg_selectedBorderColor            | `color`           | Color of border for selected button in group                               |
+| app:sbg_selectedBorderDashWidth        | `dimension`       | Width of dashes for selected button in group, 0 indicates solid line       |
+| app:sbg_selectedBorderDashGap          | `dimension`       | Width of gaps in dashes for selected button in group                       |
+| app:sbg_radius                         | `dimension`       | Radius of corners for button group                                         |
+| app:sbg_selectedButtonRadius           | `dimension`       | Radius of corners for selected button in group                             |
+| app:sbg_position                       | `integer`         | Default button that is selected                                            |
+| app:sbg_draggable                      | `boolean`         | Whether or not buttons can be dragged to change selected state             |
+| app:sbg_ripple                         | `boolean`         | Whether or not ripple effect is enabled for all buttons                    |
+| app:sbg_rippleColor                    | `color`           | Ripple effect tint color for each button                                   |
+| app:sbg_divider                        | `drawable\|color` | Drawable or color to display for divider between buttons                   |
+| app:sbg_dividerWidth                   | `dimension`       | Width of the divider between buttons, 0 indicates no dividers              |
+| app:sbg_dividerRadius                  | `dimension`       | Corner radius for divider to round edges                                   |
+| app:sbg_dividerPadding                 | `dimension`       | Divider padding on top and bottom of divider                               |
+| app:sbg_selectionAnimationDuration     | `integer`         | Duration in ms for change button selection animation                       |
+| app:sbg_selectionAnimationInterpolator | `enum`            | Type of animation used for changing button. Valid options are listed below |
 
 ### SegmentedButton
 
-| Option Name                     | Format            | Description                                                                  |
-| ------------------------------- | ----------------- | ---------------------------------------------------------------------------- |
-| android:background              | `drawable\|color` | Set background for button when unselected (default: transparent)             |
-| app:selectedBackground          | `drawable\|color` | Set background for button when selected (default: transparent)               |
-| app:rounded                     | `boolean`         | Whether or not the button is rounded.<br />**Note:** This is used to round **BOTH** sides of a button. The typical use case is for rounded buttons with a transparent background.                                        |
-| app:rippleColor                 | `color`           | Ripple effect tint color when user taps on button                            |
-| app:drawable                    | `drawable`        | Drawable to display                                                          |
-| app:drawablePadding             | `dimension`       | Padding between drawable and text                                            |
-| app:drawableTint                | `color`           | Tint color for drawable when unselected                                      |
-| app:selectedDrawableTint        | `color`           | Tint color for drawable when selected                                        |
-| app:drawableWidth               | `dimension`       | Width of drawable (default uses intrinsic)                                   |
-| app:drawableHeight              | `dimension`       | Height of drawable (default uses intrinsic)                                  |
-| app:drawableGravity             | `enum`            | Determines where drawable should be placed in relation to the text. Valid options are `Gravity.LEFT`, `Gravity.TOP`, `Gravity.RIGHT`, and `Gravity.BOTTOM`                                                     |
-| app:text                        | `string`          | Text to display on button                                                    |
-| app:textColor                   | `color`           | Color of text when button is unselected                                      |
-| app:selectedTextColor           | `color`           | Color of text when button is selected                                        |
-| app:textSize                    | `dimension`       | Font size of text                                                            |
-| android:fontFamily              | `font`            | Font for displaying text                                                     |
-| app:textStyle                   | `flag`            | Text style, can be `Typeface.NORMAL`, `Typeface.BOLD`, and `Typeface.ITALIC` |
-| app:selectedTextStyle           | `flag`            | Selected text style, can be `Typeface.NORMAL`, `Typeface.BOLD`, and `Typeface.ITALIC`
-| app:linesCount                  | `int`             | Maximum lines count, multiline by default, works with not-none ellipsize type|
-| android:ellipsize               | `enum`            | Ellipsize type, can be `none`, `start`, `middle`, `end`, `marquee`, none by default
+| Option Name                 | Format            | Description                                                                                                                                                                       |
+| ----------------------------| ----------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| android:background          | `drawable\|color` | Set background for button when unselected (default: transparent)                                                                                                                  |
+| android:fontFamily          | `font`            | Font for displaying text                                                                                                                                                          |
+| android:ellipsize           | `enum`            | Ellipsize type, can be `none`, `start`, `middle`, `end`, `marquee`, none by default                                                                                               |
+| app:sb_selectedBackground   | `drawable\|color` | Set background for button when selected (default: transparent)                                                                                                                    |
+| app:sb_rounded              | `boolean`         | Whether or not the button is rounded.<br />**Note:** This is used to round **BOTH** sides of a button. The typical use case is for rounded buttons with a transparent background. |
+| app:sb_rippleColor          | `color`           | Ripple effect tint color when user taps on button                                                                                                                                 |
+| app:sb_drawable             | `drawable`        | Drawable to display                                                                                                                                                               |
+| app:sb_drawablePadding      | `dimension`       | Padding between drawable and text                                                                                                                                                 |
+| app:sb_drawableTint         | `color`           | Tint color for drawable when unselected                                                                                                                                           |
+| app:sb_selectedDrawableTint | `color`           | Tint color for drawable when selected                                                                                                                                             |
+| app:sb_drawableWidth        | `dimension`       | Width of drawable (default uses intrinsic)                                                                                                                                        |
+| app:sb_drawableHeight       | `dimension`       | Height of drawable (default uses intrinsic)                                                                                                                                       |
+| app:sb_drawableGravity      | `enum`            | Determines where drawable should be placed in relation to the text. Valid options are `Gravity.LEFT`, `Gravity.TOP`, `Gravity.RIGHT`, and `Gravity.BOTTOM`                        |
+| app:sb_text                 | `string`          | Text to display on button                                                                                                                                                         |
+| app:sb_textColor            | `color`           | Color of text when button is unselected                                                                                                                                           |
+| app:sb_selectedTextColor    | `color`           | Color of text when button is selected                                                                                                                                             |
+| app:sb_textSize             | `dimension`       | Font size of text                                                                                                                                                                 |
+| app:sb_textStyle            | `flag`            | Text style, can be `Typeface.NORMAL`, `Typeface.BOLD`, and `Typeface.ITALIC`                                                                                                      |
+| app:sb_selectedTextStyle    | `flag`            | Selected text style, can be `Typeface.NORMAL`, `Typeface.BOLD`, and `Typeface.ITALIC`                                                                                             |
+| app:sb_linesCount           | `int`             | Maximum lines count, multiline by default, works with not-none ellipsize type                                                                                                     |
 
 **All layout attributes have a corresponding function in Java that can be called to change programatically. See Javadocs of source code for more information.**
 
@@ -223,7 +223,7 @@ Check out the [sample project](https://github.com/addisonElliott/SegmentedButton
 - linearOutSlowIn
 - overshoot
 
-These animations can be set using the attribute noted above like so: `app:selectionAnimationInterpolator="bounce"`.
+These animations can be set using the attribute noted above like so: `app:segmentedButtonGroup_selectionAnimationInterpolator="bounce"`.
 
 ## Support
 

--- a/library/src/main/java/com/addisonelliott/segmentedbutton/SegmentedButton.java
+++ b/library/src/main/java/com/addisonelliott/segmentedbutton/SegmentedButton.java
@@ -247,47 +247,47 @@ public class SegmentedButton extends View
             backgroundDrawable = ta.getDrawable(R.styleable.SegmentedButton_android_background);
 
         // Load background on selection if available, can be drawable or color
-        if (ta.hasValue(R.styleable.SegmentedButton_selectedBackground))
-            selectedBackgroundDrawable = ta.getDrawable(R.styleable.SegmentedButton_selectedBackground);
+        if (ta.hasValue(R.styleable.SegmentedButton_sb_selectedBackground))
+            selectedBackgroundDrawable = ta.getDrawable(R.styleable.SegmentedButton_sb_selectedBackground);
 
-        rounded = ta.getBoolean(R.styleable.SegmentedButton_rounded, false);
+        rounded = ta.getBoolean(R.styleable.SegmentedButton_sb_rounded, false);
 
         // Parse ripple color value and update the ripple
-        setRipple(ta.getColor(R.styleable.SegmentedButton_rippleColor, Color.GRAY));
+        setRipple(ta.getColor(R.styleable.SegmentedButton_sb_rippleColor, Color.GRAY));
 
         // Load drawable if available, otherwise variable will be null
-        if (ta.hasValue(R.styleable.SegmentedButton_drawable))
+        if (ta.hasValue(R.styleable.SegmentedButton_sb_drawable))
         {
-            int drawableResId = ta.getResourceId(R.styleable.SegmentedButton_drawable, -1);
+            int drawableResId = ta.getResourceId(R.styleable.SegmentedButton_sb_drawable, -1);
             drawable = readCompatDrawable(context, drawableResId);
         }
-        drawablePadding = ta.getDimensionPixelSize(R.styleable.SegmentedButton_drawablePadding, 0);
-        hasDrawableTint = ta.hasValue(R.styleable.SegmentedButton_drawableTint);
-        drawableTint = ta.getColor(R.styleable.SegmentedButton_drawableTint, -1);
-        hasSelectedDrawableTint = ta.hasValue(R.styleable.SegmentedButton_selectedDrawableTint);
-        selectedDrawableTint = ta.getColor(R.styleable.SegmentedButton_selectedDrawableTint, -1);
-        hasDrawableWidth = ta.hasValue(R.styleable.SegmentedButton_drawableWidth);
-        hasDrawableHeight = ta.hasValue(R.styleable.SegmentedButton_drawableHeight);
-        drawableWidth = ta.getDimensionPixelSize(R.styleable.SegmentedButton_drawableWidth, -1);
-        drawableHeight = ta.getDimensionPixelSize(R.styleable.SegmentedButton_drawableHeight, -1);
-        drawableGravity = ta.getInteger(R.styleable.SegmentedButton_drawableGravity, Gravity.LEFT);
+        drawablePadding = ta.getDimensionPixelSize(R.styleable.SegmentedButton_sb_drawablePadding, 0);
+        hasDrawableTint = ta.hasValue(R.styleable.SegmentedButton_sb_drawableTint);
+        drawableTint = ta.getColor(R.styleable.SegmentedButton_sb_drawableTint, -1);
+        hasSelectedDrawableTint = ta.hasValue(R.styleable.SegmentedButton_sb_selectedDrawableTint);
+        selectedDrawableTint = ta.getColor(R.styleable.SegmentedButton_sb_selectedDrawableTint, -1);
+        hasDrawableWidth = ta.hasValue(R.styleable.SegmentedButton_sb_drawableWidth);
+        hasDrawableHeight = ta.hasValue(R.styleable.SegmentedButton_sb_drawableHeight);
+        drawableWidth = ta.getDimensionPixelSize(R.styleable.SegmentedButton_sb_drawableWidth, -1);
+        drawableHeight = ta.getDimensionPixelSize(R.styleable.SegmentedButton_sb_drawableHeight, -1);
+        drawableGravity = ta.getInteger(R.styleable.SegmentedButton_sb_drawableGravity, Gravity.LEFT);
 
-        hasText = ta.hasValue(R.styleable.SegmentedButton_text);
-        text = ta.getString(R.styleable.SegmentedButton_text);
-        textColor = ta.getColor(R.styleable.SegmentedButton_textColor, Color.GRAY);
-        hasSelectedTextColor = ta.hasValue(R.styleable.SegmentedButton_selectedTextColor);
-        selectedTextColor = ta.getColor(R.styleable.SegmentedButton_selectedTextColor, Color.WHITE);
-        linesCount = ta.getInt(R.styleable.SegmentedButton_linesCount, Integer.MAX_VALUE);
+        hasText = ta.hasValue(R.styleable.SegmentedButton_sb_text);
+        text = ta.getString(R.styleable.SegmentedButton_sb_text);
+        textColor = ta.getColor(R.styleable.SegmentedButton_sb_textColor, Color.GRAY);
+        hasSelectedTextColor = ta.hasValue(R.styleable.SegmentedButton_sb_selectedTextColor);
+        selectedTextColor = ta.getColor(R.styleable.SegmentedButton_sb_selectedTextColor, Color.WHITE);
+        linesCount = ta.getInt(R.styleable.SegmentedButton_sb_linesCount, Integer.MAX_VALUE);
         ellipsize = resolveEllipsizeType(ta.getInt(R.styleable.SegmentedButton_android_ellipsize, 0));
 
         // Convert 14sp to pixels for default value on text size
         final float px14sp = TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_SP, 14.0f,
             context.getResources().getDisplayMetrics());
-        textSize = ta.getDimension(R.styleable.SegmentedButton_textSize, px14sp);
+        textSize = ta.getDimension(R.styleable.SegmentedButton_sb_textSize, px14sp);
 
         final boolean hasFontFamily = ta.hasValue(R.styleable.SegmentedButton_android_fontFamily);
-        final int textStyle = ta.getInt(R.styleable.SegmentedButton_textStyle, Typeface.NORMAL);
-        final int selectedTextStyle = ta.getInt(R.styleable.SegmentedButton_selectedTextStyle, textStyle);
+        final int textStyle = ta.getInt(R.styleable.SegmentedButton_sb_textStyle, Typeface.NORMAL);
+        final int selectedTextStyle = ta.getInt(R.styleable.SegmentedButton_sb_selectedTextStyle, textStyle);
 
         // If a font family is present then load typeface with text style from that
         if (hasFontFamily)

--- a/library/src/main/java/com/addisonelliott/segmentedbutton/SegmentedButtonGroup.java
+++ b/library/src/main/java/com/addisonelliott/segmentedbutton/SegmentedButtonGroup.java
@@ -276,21 +276,21 @@ public class SegmentedButtonGroup extends LinearLayout
             backgroundDrawable = ta.getDrawable(R.styleable.SegmentedButtonGroup_android_background);
 
         // Load background on selection if available, can be drawable or color
-        if (ta.hasValue(R.styleable.SegmentedButtonGroup_selectedBackground))
-            selectedBackgroundDrawable = ta.getDrawable(R.styleable.SegmentedButtonGroup_selectedBackground);
+        if (ta.hasValue(R.styleable.SegmentedButtonGroup_sbg_selectedBackground))
+            selectedBackgroundDrawable = ta.getDrawable(R.styleable.SegmentedButtonGroup_sbg_selectedBackground);
 
         // Note: Must read radius before setBorder call in order to round the border corners!
-        radius = ta.getDimensionPixelSize(R.styleable.SegmentedButtonGroup_radius, 0);
-        selectedButtonRadius = ta.getDimensionPixelSize(R.styleable.SegmentedButtonGroup_selectedButtonRadius, 0);
+        radius = ta.getDimensionPixelSize(R.styleable.SegmentedButtonGroup_sbg_radius, 0);
+        selectedButtonRadius = ta.getDimensionPixelSize(R.styleable.SegmentedButtonGroup_sbg_selectedButtonRadius, 0);
 
         // Setup border for button group
         // Width is the thickness of the border, color is the color of the border
         // Dash width and gap, if the dash width is not zero will make the border dashed with a ratio between dash
         // width and gap
-        borderWidth = ta.getDimensionPixelSize(R.styleable.SegmentedButtonGroup_borderWidth, 0);
-        borderColor = ta.getColor(R.styleable.SegmentedButtonGroup_borderColor, Color.BLACK);
-        borderDashWidth = ta.getDimensionPixelSize(R.styleable.SegmentedButtonGroup_borderDashWidth, 0);
-        borderDashGap = ta.getDimensionPixelSize(R.styleable.SegmentedButtonGroup_borderDashGap, 0);
+        borderWidth = ta.getDimensionPixelSize(R.styleable.SegmentedButtonGroup_sbg_borderWidth, 0);
+        borderColor = ta.getColor(R.styleable.SegmentedButtonGroup_sbg_borderColor, Color.BLACK);
+        borderDashWidth = ta.getDimensionPixelSize(R.styleable.SegmentedButtonGroup_sbg_borderDashWidth, 0);
+        borderDashGap = ta.getDimensionPixelSize(R.styleable.SegmentedButtonGroup_sbg_borderDashGap, 0);
 
         // Set the border to the read values, this will set the border values to itself but will create a
         // GradientDrawable containing the border
@@ -299,31 +299,31 @@ public class SegmentedButtonGroup extends LinearLayout
         // Get border information for the selected button
         // Same defaults as the border above, however this border information will be passed to each button so that
         // the correct border can be rendered around the selected button
-        selectedBorderWidth = ta.getDimensionPixelSize(R.styleable.SegmentedButtonGroup_selectedBorderWidth, 0);
-        selectedBorderColor = ta.getColor(R.styleable.SegmentedButtonGroup_selectedBorderColor, Color.BLACK);
-        selectedBorderDashWidth = ta.getDimensionPixelSize(R.styleable.SegmentedButtonGroup_selectedBorderDashWidth, 0);
-        selectedBorderDashGap = ta.getDimensionPixelSize(R.styleable.SegmentedButtonGroup_selectedBorderDashGap, 0);
+        selectedBorderWidth = ta.getDimensionPixelSize(R.styleable.SegmentedButtonGroup_sbg_selectedBorderWidth, 0);
+        selectedBorderColor = ta.getColor(R.styleable.SegmentedButtonGroup_sbg_selectedBorderColor, Color.BLACK);
+        selectedBorderDashWidth = ta.getDimensionPixelSize(R.styleable.SegmentedButtonGroup_sbg_selectedBorderDashWidth, 0);
+        selectedBorderDashGap = ta.getDimensionPixelSize(R.styleable.SegmentedButtonGroup_sbg_selectedBorderDashGap, 0);
 
-        position = ta.getInt(R.styleable.SegmentedButtonGroup_position, 0);
-        draggable = ta.getBoolean(R.styleable.SegmentedButtonGroup_draggable, false);
+        position = ta.getInt(R.styleable.SegmentedButtonGroup_sbg_position, 0);
+        draggable = ta.getBoolean(R.styleable.SegmentedButtonGroup_sbg_draggable, false);
 
         // Update clickable property
         // Not updating this property sets the clickable value to false by default but this sets the default to true
         // while keeping the clickable value if specified in the layouot XML
         setClickable(ta.getBoolean(R.styleable.SegmentedButtonGroup_android_clickable, true));
 
-        ripple = ta.getBoolean(R.styleable.SegmentedButtonGroup_ripple, true);
-        hasRippleColor = ta.hasValue(R.styleable.SegmentedButtonGroup_rippleColor);
-        rippleColor = ta.getColor(R.styleable.SegmentedButtonGroup_rippleColor, Color.GRAY);
+        ripple = ta.getBoolean(R.styleable.SegmentedButtonGroup_sbg_ripple, true);
+        hasRippleColor = ta.hasValue(R.styleable.SegmentedButtonGroup_sbg_rippleColor);
+        rippleColor = ta.getColor(R.styleable.SegmentedButtonGroup_sbg_rippleColor, Color.GRAY);
 
-        final int dividerWidth = ta.getDimensionPixelSize(R.styleable.SegmentedButtonGroup_dividerWidth, 1);
-        final int dividerRadius = ta.getDimensionPixelSize(R.styleable.SegmentedButtonGroup_dividerRadius, 0);
-        final int dividerPadding = ta.getDimensionPixelSize(R.styleable.SegmentedButtonGroup_dividerPadding, 0);
+        final int dividerWidth = ta.getDimensionPixelSize(R.styleable.SegmentedButtonGroup_sbg_dividerWidth, 1);
+        final int dividerRadius = ta.getDimensionPixelSize(R.styleable.SegmentedButtonGroup_sbg_dividerRadius, 0);
+        final int dividerPadding = ta.getDimensionPixelSize(R.styleable.SegmentedButtonGroup_sbg_dividerPadding, 0);
 
         // Load divider value if available, the divider can be either a drawable resource or a color
         // Load the TypedValue first and check the type to determine if color or drawable
         final TypedValue value = new TypedValue();
-        if (ta.getValue(R.styleable.SegmentedButtonGroup_divider, value))
+        if (ta.getValue(R.styleable.SegmentedButtonGroup_sbg_divider, value))
         {
             if (value.type == TypedValue.TYPE_REFERENCE || value.type == TypedValue.TYPE_STRING)
             {
@@ -333,7 +333,7 @@ public class SegmentedButtonGroup extends LinearLayout
                 // Loading drawable TypedArray.getDrawable or doing TypedArray.getResourceId fixes the problem
                 if (isInEditMode())
                 {
-                    setDivider(ta.getDrawable(R.styleable.SegmentedButtonGroup_divider), dividerWidth, dividerRadius,
+                    setDivider(ta.getDrawable(R.styleable.SegmentedButtonGroup_sbg_divider), dividerWidth, dividerRadius,
                         dividerPadding);
                 }
                 else
@@ -355,10 +355,10 @@ public class SegmentedButtonGroup extends LinearLayout
             }
         }
 
-        int selectionAnimationInterpolator = ta.getInt(R.styleable.SegmentedButtonGroup_selectionAnimationInterpolator,
+        int selectionAnimationInterpolator = ta.getInt(R.styleable.SegmentedButtonGroup_sbg_selectionAnimationInterpolator,
             ANIM_INTERPOLATOR_FAST_OUT_SLOW_IN);
         setSelectionAnimationInterpolator(selectionAnimationInterpolator);
-        selectionAnimationDuration = ta.getInt(R.styleable.SegmentedButtonGroup_selectionAnimationDuration, 500);
+        selectionAnimationDuration = ta.getInt(R.styleable.SegmentedButtonGroup_sbg_selectionAnimationDuration, 500);
 
         // Recycle the typed array, required once done using it
         ta.recycle();

--- a/library/src/main/res/values/attrs.xml
+++ b/library/src/main/res/values/attrs.xml
@@ -1,37 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <declare-styleable name="GlobalAttrs">
-        <attr name="rippleColor" format="color" />
-
-        <attr name="selectedBackground" format="reference|color" />
-    </declare-styleable>
-
     <declare-styleable name="SegmentedButton">
         <attr name="android:background" />
-        <attr name="selectedBackground" />
-
-        <attr name="rounded" format="boolean" />
-
-        <attr name="rippleColor" />
-
-        <attr name="drawable" format="reference" />
-        <attr name="drawablePadding" format="dimension" />
-        <attr name="drawableTint" format="color" />
-        <attr name="selectedDrawableTint" format="color" />
-        <attr name="drawableWidth" format="dimension" />
-        <attr name="drawableHeight" format="dimension" />
-        <attr name="drawableGravity" format="integer">
-            <flag name="top" value="0x30" />
-            <flag name="bottom" value="0x50" />
-            <flag name="left" value="0x03" />
-            <flag name="right" value="0x05" />
-        </attr>
-
-        <attr name="text" format="string" />
-        <attr name="textColor" format="color" />
-        <attr name="selectedTextColor" format="color" />
-        <attr name="textSize" format="dimension" />
-        <attr name="linesCount" format="integer" />
+        <attr name="android:fontFamily" format="string" />
         <attr name="android:ellipsize">
             <enum name="none" value="0" />
             <enum name="start" value="1" />
@@ -39,13 +10,34 @@
             <enum name="end" value="3" />
             <enum name="marquee" value="4" />
         </attr>
-        <attr name="android:fontFamily" format="string" />
-        <attr name="textStyle" format="integer">
+
+        <attr name="sb_selectedBackground" format="reference|color" />
+        <attr name="sb_rippleColor" format="color" />
+        <attr name="sb_rounded" format="boolean" />
+        <attr name="sb_drawable" format="reference" />
+        <attr name="sb_drawablePadding" format="dimension" />
+        <attr name="sb_drawableTint" format="color" />
+        <attr name="sb_selectedDrawableTint" format="color" />
+        <attr name="sb_drawableWidth" format="dimension" />
+        <attr name="sb_drawableHeight" format="dimension" />
+        <attr name="sb_drawableGravity" format="integer">
+            <flag name="top" value="0x30" />
+            <flag name="bottom" value="0x50" />
+            <flag name="left" value="0x03" />
+            <flag name="right" value="0x05" />
+        </attr>
+
+        <attr name="sb_text" format="string" />
+        <attr name="sb_textColor" format="color" />
+        <attr name="sb_selectedTextColor" format="color" />
+        <attr name="sb_textSize" format="dimension" />
+        <attr name="sb_linesCount" format="integer" />
+        <attr name="sb_textStyle" format="integer">
             <flag name="normal" value="0" />
             <flag name="bold" value="1" />
             <flag name="italic" value="2" />
         </attr>
-        <attr name="selectedTextStyle" format="integer">
+        <attr name="sb_selectedTextStyle" format="integer">
             <flag name="normal" value="0" />
             <flag name="bold" value="1" />
             <flag name="italic" value="2" />
@@ -54,34 +46,33 @@
 
     <declare-styleable name="SegmentedButtonGroup">
         <attr name="android:background" />
-        <attr name="selectedBackground" />
-
-        <attr name="borderWidth" format="dimension" />
-        <attr name="borderColor" format="color" />
-        <attr name="borderDashWidth" format="dimension" />
-        <attr name="borderDashGap" format="dimension" />
-
-        <attr name="selectedBorderWidth" format="dimension" />
-        <attr name="selectedBorderColor" format="color" />
-        <attr name="selectedBorderDashWidth" format="dimension" />
-        <attr name="selectedBorderDashGap" format="dimension" />
-
-        <attr name="radius" format="dimension" />
-        <attr name="selectedButtonRadius" format="dimension" />
-        <attr name="position" format="integer" />
-        <attr name="draggable" format="boolean" />
         <attr name="android:clickable" />
 
-        <attr name="ripple" format="boolean" />
-        <attr name="rippleColor" />
+        <attr name="sbg_borderWidth" format="dimension" />
+        <attr name="sbg_borderColor" format="color" />
+        <attr name="sbg_borderDashWidth" format="dimension" />
+        <attr name="sbg_borderDashGap" format="dimension" />
 
-        <attr name="divider" />
-        <attr name="dividerWidth" format="dimension" />
-        <attr name="dividerRadius" format="dimension" />
-        <attr name="dividerPadding" format="dimension" />
+        <attr name="sbg_selectedBackground" format="reference|color" />
+        <attr name="sbg_selectedBorderWidth" format="dimension" />
+        <attr name="sbg_selectedBorderColor" format="color" />
+        <attr name="sbg_selectedBorderDashWidth" format="dimension" />
+        <attr name="sbg_selectedBorderDashGap" format="dimension" />
 
-        <attr name="selectionAnimationDuration" format="integer" />
-        <attr name="selectionAnimationInterpolator" format="enum">
+        <attr name="sbg_radius" format="dimension" />
+        <attr name="sbg_selectedButtonRadius" format="dimension" />
+        <attr name="sbg_position" format="integer" />
+        <attr name="sbg_draggable" format="boolean" />
+        <attr name="sbg_ripple" format="boolean" />
+        <attr name="sbg_rippleColor" format="color" />
+
+        <attr name="sbg_divider" format="reference" />
+        <attr name="sbg_dividerWidth" format="dimension" />
+        <attr name="sbg_dividerRadius" format="dimension" />
+        <attr name="sbg_dividerPadding" format="dimension" />
+
+        <attr name="sbg_selectionAnimationDuration" format="integer" />
+        <attr name="sbg_selectionAnimationInterpolator" format="enum">
             <enum name="none" value="-1" />
             <enum name="fastOutSlowIn" value="0" />
             <enum name="bounce" value="1" />

--- a/sample/src/main/res/layout/activity_main.xml
+++ b/sample/src/main/res/layout/activity_main.xml
@@ -2,7 +2,6 @@
 
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/scrollView"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -48,44 +47,44 @@
                 android:layout_gravity="center_vertical"
                 android:elevation="2dp"
                 android:background="@drawable/gradient_drawable"
-                app:divider="@drawable/gradient_drawable_divider"
-                app:dividerPadding="10dp"
-                app:dividerRadius="10dp"
-                app:dividerWidth="4dp"
-                app:position="1"
-                app:radius="2dp"
-                app:ripple="true"
-                app:rippleColor="@color/blue_300"
-                app:selectedBackground="@drawable/gradient_drawable_selector"
-                app:selectionAnimationDuration="1000"
-                app:selectionAnimationInterpolator="fastOutSlowIn">
+                app:sbg_divider="@drawable/gradient_drawable_divider"
+                app:sbg_dividerPadding="10dp"
+                app:sbg_dividerRadius="10dp"
+                app:sbg_dividerWidth="4dp"
+                app:sbg_position="1"
+                app:sbg_radius="2dp"
+                app:sbg_ripple="true"
+                app:sbg_rippleColor="@color/blue_300"
+                app:sbg_selectedBackground="@drawable/gradient_drawable_selector"
+                app:sbg_selectionAnimationDuration="1000"
+                app:sbg_selectionAnimationInterpolator="fastOutSlowIn">
 
                 <com.addisonelliott.segmentedbutton.SegmentedButton
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
                     android:padding="8dp"
-                    app:selectedTextColor="@color/white"
-                    app:text="Button 1"
-                    app:textColor="@color/black" />
+                    app:sb_selectedTextColor="@color/white"
+                    app:sb_text="Button 1"
+                    app:sb_textColor="@color/black" />
 
                 <com.addisonelliott.segmentedbutton.SegmentedButton
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
                     android:padding="8dp"
-                    app:selectedTextColor="@color/white"
-                    app:text="Button 2"
-                    app:textColor="@color/black" />
+                    app:sb_selectedTextColor="@color/white"
+                    app:sb_text="Button 2"
+                    app:sb_textColor="@color/black" />
 
                 <com.addisonelliott.segmentedbutton.SegmentedButton
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
                     android:padding="8dp"
-                    app:selectedTextColor="@color/white"
-                    app:text="Button 3"
-                    app:textColor="@color/black" />
+                    app:sb_selectedTextColor="@color/white"
+                    app:sb_text="Button 3"
+                    app:sb_textColor="@color/black" />
             </com.addisonelliott.segmentedbutton.SegmentedButtonGroup>
 
         </LinearLayout>
@@ -98,16 +97,16 @@
             android:layout_margin="4dp"
             android:elevation="2dp"
             android:background="#FFFFFF"
-            app:borderColor="@color/orange_700"
-            app:borderWidth="1dp"
-            app:divider="@color/orange_700"
-            app:dividerPadding="10dp"
-            app:dividerWidth="1dp"
-            app:position="0"
-            app:radius="30dp"
-            app:ripple="true"
-            app:rippleColor="@color/green_800"
-            app:selectedBackground="@color/green_900">
+            app:sbg_borderColor="@color/orange_700"
+            app:sbg_borderWidth="1dp"
+            app:sbg_divider="@color/orange_700"
+            app:sbg_dividerPadding="10dp"
+            app:sbg_dividerWidth="1dp"
+            app:sbg_position="0"
+            app:sbg_radius="30dp"
+            app:sbg_ripple="true"
+            app:sbg_rippleColor="@color/green_800"
+            app:sbg_selectedBackground="@color/green_900">
 
             <com.addisonelliott.segmentedbutton.SegmentedButton
                 android:layout_width="0dp"
@@ -115,11 +114,11 @@
                 android:layout_weight="1"
                 android:fontFamily="@font/aniron"
                 android:padding="10dp"
-                app:drawable="@drawable/ic_aragorn"
-                app:drawableGravity="top"
-                app:selectedTextColor="@color/orange_700"
-                app:text="Aragorn"
-                app:textColor="@color/black" />
+                app:sb_drawable="@drawable/ic_aragorn"
+                app:sb_drawableGravity="top"
+                app:sb_selectedTextColor="@color/orange_700"
+                app:sb_text="Aragorn"
+                app:sb_textColor="@color/black" />
 
             <com.addisonelliott.segmentedbutton.SegmentedButton
                 android:layout_width="0dp"
@@ -127,11 +126,11 @@
                 android:layout_weight="1"
                 android:fontFamily="@font/aniron"
                 android:padding="10dp"
-                app:drawable="@drawable/ic_gimli"
-                app:drawableGravity="top"
-                app:selectedTextColor="@color/grey_600"
-                app:text="Gimli"
-                app:textColor="@color/black" />
+                app:sb_drawable="@drawable/ic_gimli"
+                app:sb_drawableGravity="top"
+                app:sb_selectedTextColor="@color/grey_600"
+                app:sb_text="Gimli"
+                app:sb_textColor="@color/black" />
 
             <com.addisonelliott.segmentedbutton.SegmentedButton
                 android:layout_width="0dp"
@@ -139,11 +138,11 @@
                 android:layout_weight="1"
                 android:fontFamily="@font/aniron"
                 android:padding="10dp"
-                app:drawable="@drawable/ic_legolas"
-                app:drawableGravity="top"
-                app:selectedTextColor="@color/yellow_200"
-                app:text="Legolas"
-                app:textColor="@color/black" />
+                app:sb_drawable="@drawable/ic_legolas"
+                app:sb_drawableGravity="top"
+                app:sb_selectedTextColor="@color/yellow_200"
+                app:sb_text="Legolas"
+                app:sb_textColor="@color/black" />
         </com.addisonelliott.segmentedbutton.SegmentedButtonGroup>
 
         <com.addisonelliott.segmentedbutton.SegmentedButtonGroup
@@ -153,16 +152,16 @@
             android:layout_margin="10dp"
             android:elevation="2dp"
             android:background="@color/red_700"
-            app:borderColor="@color/black"
-            app:borderWidth="1dp"
-            app:divider="@color/black"
-            app:dividerPadding="10dp"
-            app:dividerRadius="10dp"
-            app:dividerWidth="1dp"
-            app:radius="2dp"
-            app:selectedBackground="@color/black"
-            app:selectionAnimationDuration="1000"
-            app:selectionAnimationInterpolator="bounce">
+            app:sbg_borderColor="@color/black"
+            app:sbg_borderWidth="1dp"
+            app:sbg_divider="@color/black"
+            app:sbg_dividerPadding="10dp"
+            app:sbg_dividerRadius="10dp"
+            app:sbg_dividerWidth="1dp"
+            app:sbg_radius="2dp"
+            app:sbg_selectedBackground="@color/black"
+            app:sbg_selectionAnimationDuration="1000"
+            app:sbg_selectionAnimationInterpolator="bounce">
 
             <com.addisonelliott.segmentedbutton.SegmentedButton
                 android:layout_width="0dp"
@@ -171,13 +170,13 @@
                 android:drawablePadding="4dp"
                 android:fontFamily="@font/shaka_pow"
                 android:padding="10dp"
-                app:drawable="@drawable/ic_b5"
-                app:drawableGravity="left"
-                app:rippleColor="@color/blue_500"
-                app:selectedDrawableTint="@color/yellow_500"
-                app:selectedTextColor="@color/red_500"
-                app:text="Diana"
-                app:textColor="@color/black" />
+                app:sb_drawable="@drawable/ic_b5"
+                app:sb_drawableGravity="left"
+                app:sb_rippleColor="@color/blue_500"
+                app:sb_selectedDrawableTint="@color/yellow_500"
+                app:sb_selectedTextColor="@color/red_500"
+                app:sb_text="Diana"
+                app:sb_textColor="@color/black" />
 
             <com.addisonelliott.segmentedbutton.SegmentedButton
                 android:layout_width="0dp"
@@ -186,13 +185,13 @@
                 android:drawablePadding="4dp"
                 android:fontFamily="@font/shaka_pow"
                 android:padding="10dp"
-                app:drawable="@drawable/ic_b4"
-                app:drawableGravity="top"
-                app:rippleColor="@color/black"
-                app:selectedDrawableTint="@color/grey_500"
-                app:selectedTextColor="@color/yellow_500"
-                app:text="Batman"
-                app:textColor="@color/black" />
+                app:sb_drawable="@drawable/ic_b4"
+                app:sb_drawableGravity="top"
+                app:sb_rippleColor="@color/black"
+                app:sb_selectedDrawableTint="@color/grey_500"
+                app:sb_selectedTextColor="@color/yellow_500"
+                app:sb_text="Batman"
+                app:sb_textColor="@color/black" />
 
             <com.addisonelliott.segmentedbutton.SegmentedButton
                 android:layout_width="0dp"
@@ -201,13 +200,13 @@
                 android:drawablePadding="4dp"
                 android:fontFamily="@font/shaka_pow"
                 android:padding="10dp"
-                app:drawable="@drawable/ic_b3"
-                app:drawableGravity="right"
-                app:rippleColor="@color/yellow_500"
-                app:selectedDrawableTint="@color/blue_500"
-                app:selectedTextColor="@color/red_500"
-                app:text="Clark"
-                app:textColor="@color/black" />
+                app:sb_drawable="@drawable/ic_b3"
+                app:sb_drawableGravity="right"
+                app:sb_rippleColor="@color/yellow_500"
+                app:sb_selectedDrawableTint="@color/blue_500"
+                app:sb_selectedTextColor="@color/red_500"
+                app:sb_text="Clark"
+                app:sb_textColor="@color/black" />
         </com.addisonelliott.segmentedbutton.SegmentedButtonGroup>
 
         <LinearLayout
@@ -223,32 +222,32 @@
                 android:layout_weight="1"
                 android:elevation="2dp"
                 android:background="@color/white"
-                app:borderColor="@color/black"
-                app:borderWidth="1dp"
-                app:divider="@color/black"
-                app:dividerWidth="2dp"
-                app:position="0"
-                app:radius="30dp"
-                app:rippleColor="@color/blue_300"
-                app:selectedBackground="@color/yellow_600">
+                app:sbg_borderColor="@color/black"
+                app:sbg_borderWidth="1dp"
+                app:sbg_divider="@color/black"
+                app:sbg_dividerWidth="2dp"
+                app:sbg_position="0"
+                app:sbg_radius="30dp"
+                app:sbg_rippleColor="@color/blue_300"
+                app:sbg_selectedBackground="@color/yellow_600">
 
                 <com.addisonelliott.segmentedbutton.SegmentedButton
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
                     android:padding="8dp"
-                    app:drawable="@drawable/ic_b1"
-                    app:drawableTint="@color/yellow_600"
-                    app:selectedDrawableTint="@color/black" />
+                    app:sb_drawable="@drawable/ic_b1"
+                    app:sb_drawableTint="@color/yellow_600"
+                    app:sb_selectedDrawableTint="@color/black" />
 
                 <com.addisonelliott.segmentedbutton.SegmentedButton
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
                     android:padding="8dp"
-                    app:drawable="@drawable/ic_b2"
-                    app:drawableTint="@color/DarkRed"
-                    app:selectedDrawableTint="@color/black" />
+                    app:sb_drawable="@drawable/ic_b2"
+                    app:sb_drawableTint="@color/DarkRed"
+                    app:sb_selectedDrawableTint="@color/black" />
 
             </com.addisonelliott.segmentedbutton.SegmentedButtonGroup>
 
@@ -260,26 +259,26 @@
                 android:layout_weight="1"
                 android:elevation="2dp"
                 android:background="@color/white"
-                app:divider="@color/yellow_600"
-                app:dividerWidth="2dp"
-                app:position="0"
-                app:radius="30dp"
-                app:rippleColor="@color/black"
-                app:selectedBackground="@color/DarkRed">
+                app:sbg_divider="@color/yellow_600"
+                app:sbg_dividerWidth="2dp"
+                app:sbg_position="0"
+                app:sbg_radius="30dp"
+                app:sbg_rippleColor="@color/black"
+                app:sbg_selectedBackground="@color/DarkRed">
 
                 <com.addisonelliott.segmentedbutton.SegmentedButton
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
                     android:padding="8dp"
-                    app:drawable="@drawable/ic_b17" />
+                    app:sb_drawable="@drawable/ic_b17" />
 
                 <com.addisonelliott.segmentedbutton.SegmentedButton
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
                     android:padding="8dp"
-                    app:drawable="@drawable/ic_b6" />
+                    app:sb_drawable="@drawable/ic_b6" />
 
             </com.addisonelliott.segmentedbutton.SegmentedButtonGroup>
         </LinearLayout>
@@ -292,14 +291,14 @@
             android:layout_margin="4dp"
             android:elevation="2dp"
             android:background="@color/red_400"
-            app:divider="@color/white"
-            app:dividerPadding="10dp"
-            app:dividerRadius="10dp"
-            app:dividerWidth="2dp"
-            app:position="1"
-            app:radius="2dp"
-            app:rippleColor="@color/red_200"
-            app:selectedBackground="@color/green_200">
+            app:sbg_divider="@color/white"
+            app:sbg_dividerPadding="10dp"
+            app:sbg_dividerRadius="10dp"
+            app:sbg_dividerWidth="2dp"
+            app:sbg_position="1"
+            app:sbg_radius="2dp"
+            app:sbg_rippleColor="@color/red_200"
+            app:sbg_selectedBackground="@color/green_200">
 
             <com.addisonelliott.segmentedbutton.SegmentedButton
                 android:layout_width="0dp"
@@ -309,7 +308,7 @@
                 android:paddingLeft="20dp"
                 android:paddingRight="20dp"
                 android:paddingTop="6dp"
-                app:drawable="@drawable/ic_b8" />
+                app:sb_drawable="@drawable/ic_b8" />
 
             <com.addisonelliott.segmentedbutton.SegmentedButton
                 android:layout_width="0dp"
@@ -319,7 +318,7 @@
                 android:paddingLeft="45dp"
                 android:paddingRight="45dp"
                 android:paddingTop="6dp"
-                app:drawable="@drawable/ic_b9" />
+                app:sb_drawable="@drawable/ic_b9" />
 
             <com.addisonelliott.segmentedbutton.SegmentedButton
                 android:layout_width="0dp"
@@ -329,7 +328,7 @@
                 android:paddingLeft="20dp"
                 android:paddingRight="20dp"
                 android:paddingTop="6dp"
-                app:drawable="@drawable/ic_b11" />
+                app:sb_drawable="@drawable/ic_b11" />
 
         </com.addisonelliott.segmentedbutton.SegmentedButtonGroup>
 
@@ -340,52 +339,52 @@
             android:layout_margin="4dp"
             android:elevation="2dp"
             android:background="@color/black"
-            app:position="2"
-            app:radius="2dp"
-            app:rippleColor="@color/white"
-            app:selectedBackground="@color/white"
-            app:selectionAnimationDuration="1000"
-            app:selectionAnimationInterpolator="fastOutSlowIn">
+            app:sbg_position="2"
+            app:sbg_radius="2dp"
+            app:sbg_rippleColor="@color/white"
+            app:sbg_selectedBackground="@color/white"
+            app:sbg_selectionAnimationDuration="1000"
+            app:sbg_selectionAnimationInterpolator="fastOutSlowIn">
 
             <com.addisonelliott.segmentedbutton.SegmentedButton
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_weight="1"
-                app:drawable="@drawable/ic_b7"
-                app:drawableTint="@color/white"
-                app:selectedDrawableTint="@color/black" />
+                app:sb_drawable="@drawable/ic_b7"
+                app:sb_drawableTint="@color/white"
+                app:sb_selectedDrawableTint="@color/black" />
 
             <com.addisonelliott.segmentedbutton.SegmentedButton
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_weight="1.5"
-                app:drawable="@drawable/ic_b7"
-                app:drawableTint="@color/white"
-                app:selectedDrawableTint="@color/black" />
+                app:sb_drawable="@drawable/ic_b7"
+                app:sb_drawableTint="@color/white"
+                app:sb_selectedDrawableTint="@color/black" />
 
             <com.addisonelliott.segmentedbutton.SegmentedButton
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_weight="2"
-                app:drawable="@drawable/ic_b7"
-                app:drawableTint="@color/white"
-                app:selectedDrawableTint="@color/black" />
+                app:sb_drawable="@drawable/ic_b7"
+                app:sb_drawableTint="@color/white"
+                app:sb_selectedDrawableTint="@color/black" />
 
             <com.addisonelliott.segmentedbutton.SegmentedButton
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_weight="1.5"
-                app:drawable="@drawable/ic_b7"
-                app:drawableTint="@color/white"
-                app:selectedDrawableTint="@color/black" />
+                app:sb_drawable="@drawable/ic_b7"
+                app:sb_drawableTint="@color/white"
+                app:sb_selectedDrawableTint="@color/black" />
 
             <com.addisonelliott.segmentedbutton.SegmentedButton
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_weight="1"
-                app:drawable="@drawable/ic_b7"
-                app:drawableTint="@color/white"
-                app:selectedDrawableTint="@color/black" />
+                app:sb_drawable="@drawable/ic_b7"
+                app:sb_drawableTint="@color/white"
+                app:sb_selectedDrawableTint="@color/black" />
 
         </com.addisonelliott.segmentedbutton.SegmentedButtonGroup>
 
@@ -405,14 +404,14 @@
             android:layout_margin="4dp"
             android:elevation="2dp"
             android:background="@color/white"
-            app:borderColor="@color/black"
-            app:borderWidth="1dp"
-            app:draggable="true"
-            app:position="0"
-            app:radius="30dp"
-            app:rippleColor="@color/black"
-            app:selectedBackground="@color/green_800"
-            app:selectionAnimationDuration="1000">
+            app:sbg_borderColor="@color/black"
+            app:sbg_borderWidth="1dp"
+            app:sbg_draggable="true"
+            app:sbg_position="0"
+            app:sbg_radius="30dp"
+            app:sbg_rippleColor="@color/black"
+            app:sbg_selectedBackground="@color/green_800"
+            app:sbg_selectionAnimationDuration="1000">
 
             <com.addisonelliott.segmentedbutton.SegmentedButton
                 android:layout_width="0dp"
@@ -420,11 +419,11 @@
                 android:layout_weight="1"
                 android:fontFamily="sans-serif-light"
                 android:padding="8dp"
-                app:selectedTextColor="@color/white"
-                app:selectedTextStyle="bold"
-                app:text="YES"
-                app:textColor="@color/black"
-                app:textSize="24sp" />
+                app:sb_selectedTextColor="@color/white"
+                app:sb_selectedTextStyle="bold"
+                app:sb_text="YES"
+                app:sb_textColor="@color/black"
+                app:sb_textSize="24sp" />
 
             <com.addisonelliott.segmentedbutton.SegmentedButton
                 android:layout_width="0dp"
@@ -432,11 +431,11 @@
                 android:layout_weight="1"
                 android:fontFamily="sans-serif-light"
                 android:padding="8dp"
-                app:selectedTextColor="@color/white"
-                app:selectedTextStyle="bold"
-                app:text="Maybe"
-                app:textColor="@color/black"
-                app:textSize="24sp" />
+                app:sb_selectedTextColor="@color/white"
+                app:sb_selectedTextStyle="bold"
+                app:sb_text="Maybe"
+                app:sb_textColor="@color/black"
+                app:sb_textSize="24sp" />
 
             <com.addisonelliott.segmentedbutton.SegmentedButton
                 android:layout_width="0dp"
@@ -444,11 +443,11 @@
                 android:layout_weight="1"
                 android:fontFamily="sans-serif-light"
                 android:padding="8dp"
-                app:selectedTextColor="@color/white"
-                app:selectedTextStyle="bold"
-                app:text="NO"
-                app:textColor="@color/black"
-                app:textSize="24sp" />
+                app:sb_selectedTextColor="@color/white"
+                app:sb_selectedTextStyle="bold"
+                app:sb_text="NO"
+                app:sb_textColor="@color/black"
+                app:sb_textSize="24sp" />
 
         </com.addisonelliott.segmentedbutton.SegmentedButtonGroup>
 
@@ -468,12 +467,12 @@
             android:layout_margin="4dp"
             android:elevation="2dp"
             android:background="@color/black"
-            app:position="0"
-            app:radius="2dp"
-            app:rippleColor="@color/white"
-            app:selectedBackground="@color/white"
-            app:selectionAnimationDuration="1000"
-            app:selectionAnimationInterpolator="fastOutSlowIn">
+            app:sbg_position="0"
+            app:sbg_radius="2dp"
+            app:sbg_rippleColor="@color/white"
+            app:sbg_selectedBackground="@color/white"
+            app:sbg_selectionAnimationDuration="1000"
+            app:sbg_selectionAnimationInterpolator="fastOutSlowIn">
 
             <com.addisonelliott.segmentedbutton.SegmentedButton
                 android:id="@+id/button_left"
@@ -481,11 +480,11 @@
                 android:layout_height="match_parent"
                 android:layout_weight="1"
                 android:padding="8dp"
-                app:drawableGravity="right"
-                app:drawablePadding="8dp"
-                app:drawableTint="@color/white"
-                app:selectedDrawableTint="@color/black"
-                app:text="Left" />
+                app:sb_drawableGravity="right"
+                app:sb_drawablePadding="8dp"
+                app:sb_drawableTint="@color/white"
+                app:sb_selectedDrawableTint="@color/black"
+                app:sb_text="Left" />
 
             <com.addisonelliott.segmentedbutton.SegmentedButton
                 android:id="@+id/button_right"
@@ -493,10 +492,10 @@
                 android:layout_height="match_parent"
                 android:layout_weight="1"
                 android:padding="8dp"
-                app:drawableGravity="right"
-                app:drawableTint="@color/white"
-                app:selectedDrawableTint="@color/black"
-                app:text="Right" />
+                app:sb_drawableGravity="right"
+                app:sb_drawableTint="@color/white"
+                app:sb_selectedDrawableTint="@color/black"
+                app:sb_text="Right" />
 
         </com.addisonelliott.segmentedbutton.SegmentedButtonGroup>
 
@@ -507,11 +506,11 @@
             android:layout_margin="4dp"
             android:elevation="3dp"
             android:background="@color/white"
-            app:position="0"
-            app:radius="20dp"
-            app:ripple="true"
-            app:rippleColor="@color/green_800"
-            app:selectedBackground="@color/blue_600">
+            app:sbg_position="0"
+            app:sbg_radius="20dp"
+            app:sbg_ripple="true"
+            app:sbg_rippleColor="@color/green_800"
+            app:sbg_selectedBackground="@color/blue_600">
 
             <com.addisonelliott.segmentedbutton.SegmentedButton
                 android:layout_width="0dp"
@@ -519,9 +518,9 @@
                 android:layout_weight="1"
                 android:padding="4dp"
                 android:background="@color/red_100"
-                app:selectedTextColor="@color/white"
-                app:text="Both"
-                app:textColor="@color/red" />
+                app:sb_selectedTextColor="@color/white"
+                app:sb_text="Both"
+                app:sb_textColor="@color/red" />
 
             <com.addisonelliott.segmentedbutton.SegmentedButton
                 android:layout_width="0dp"
@@ -529,9 +528,9 @@
                 android:layout_weight="1"
                 android:padding="8dp"
                 android:background="@color/green_100"
-                app:selectedTextColor="@color/white"
-                app:text="Pickup"
-                app:textColor="@color/black" />
+                app:sb_selectedTextColor="@color/white"
+                app:sb_text="Pickup"
+                app:sb_textColor="@color/black" />
 
             <com.addisonelliott.segmentedbutton.SegmentedButton
                 android:layout_width="0dp"
@@ -539,9 +538,9 @@
                 android:layout_weight="1"
                 android:padding="4dp"
                 android:background="@color/blue_100"
-                app:selectedTextColor="@color/white"
-                app:text="Dropoff"
-                app:textColor="@color/black" />
+                app:sb_selectedTextColor="@color/white"
+                app:sb_text="Dropoff"
+                app:sb_textColor="@color/black" />
 
         </com.addisonelliott.segmentedbutton.SegmentedButtonGroup>
 
@@ -553,35 +552,35 @@
             android:layout_margin="4dp"
             android:elevation="2dp"
             android:background="@color/red_400"
-            app:divider="@color/white"
-            app:dividerPadding="10dp"
-            app:dividerRadius="10dp"
-            app:dividerWidth="2dp"
-            app:position="0"
-            app:radius="2dp"
-            app:rippleColor="@color/red_200"
-            app:selectedBackground="@color/green_200">
+            app:sbg_divider="@color/white"
+            app:sbg_dividerPadding="10dp"
+            app:sbg_dividerRadius="10dp"
+            app:sbg_dividerWidth="2dp"
+            app:sbg_position="0"
+            app:sbg_radius="2dp"
+            app:sbg_rippleColor="@color/red_200"
+            app:sbg_selectedBackground="@color/green_200">
 
             <com.addisonelliott.segmentedbutton.SegmentedButton
                 android:layout_width="96dp"
                 android:layout_height="wrap_content"
                 android:paddingBottom="6dp"
                 android:paddingTop="6dp"
-                app:drawable="@drawable/ic_b8" />
+                app:sb_drawable="@drawable/ic_b8" />
 
             <com.addisonelliott.segmentedbutton.SegmentedButton
                 android:layout_width="128dp"
                 android:layout_height="wrap_content"
                 android:paddingBottom="6dp"
                 android:paddingTop="6dp"
-                app:drawable="@drawable/ic_b9" />
+                app:sb_drawable="@drawable/ic_b9" />
 
             <com.addisonelliott.segmentedbutton.SegmentedButton
                 android:layout_width="96dp"
                 android:layout_height="wrap_content"
                 android:paddingBottom="6dp"
                 android:paddingTop="6dp"
-                app:drawable="@drawable/ic_b11" />
+                app:sb_drawable="@drawable/ic_b11" />
 
         </com.addisonelliott.segmentedbutton.SegmentedButtonGroup>
 
@@ -592,14 +591,14 @@
             android:layout_margin="4dp"
             android:elevation="2dp"
             android:background="@color/white"
-            app:position="0"
-            app:radius="30dp"
-            app:rippleColor="@color/black"
-            app:selectedBackground="@color/blue_500"
-            app:selectedBorderColor="#555555"
-            app:selectedBorderWidth="2dp"
-            app:selectedButtonRadius="30dp"
-            app:selectionAnimationDuration="1000">
+            app:sbg_position="0"
+            app:sbg_radius="30dp"
+            app:sbg_rippleColor="@color/black"
+            app:sbg_selectedBackground="@color/blue_500"
+            app:sbg_selectedBorderColor="#555555"
+            app:sbg_selectedBorderWidth="2dp"
+            app:sbg_selectedButtonRadius="30dp"
+            app:sbg_selectionAnimationDuration="1000">
 
             <com.addisonelliott.segmentedbutton.SegmentedButton
                 android:layout_width="0dp"
@@ -607,10 +606,10 @@
                 android:layout_weight="1"
                 android:fontFamily="sans-serif-light"
                 android:padding="8dp"
-                app:selectedTextColor="@color/white"
-                app:text="Yes"
-                app:textColor="@color/black"
-                app:textSize="24sp" />
+                app:sb_selectedTextColor="@color/white"
+                app:sb_text="Yes"
+                app:sb_textColor="@color/black"
+                app:sb_textSize="24sp" />
 
             <com.addisonelliott.segmentedbutton.SegmentedButton
                 android:layout_width="0dp"
@@ -618,10 +617,10 @@
                 android:layout_weight="1"
                 android:fontFamily="sans-serif-light"
                 android:padding="8dp"
-                app:selectedTextColor="@color/white"
-                app:text="Maybe"
-                app:textColor="@color/black"
-                app:textSize="24sp" />
+                app:sb_selectedTextColor="@color/white"
+                app:sb_text="Maybe"
+                app:sb_textColor="@color/black"
+                app:sb_textSize="24sp" />
 
             <com.addisonelliott.segmentedbutton.SegmentedButton
                 android:layout_width="0dp"
@@ -629,10 +628,10 @@
                 android:layout_weight="1"
                 android:fontFamily="sans-serif-light"
                 android:padding="8dp"
-                app:selectedTextColor="#FFFFFF"
-                app:text="No"
-                app:textColor="@color/black"
-                app:textSize="24sp" />
+                app:sb_selectedTextColor="#FFFFFF"
+                app:sb_text="No"
+                app:sb_textColor="@color/black"
+                app:sb_textSize="24sp" />
 
         </com.addisonelliott.segmentedbutton.SegmentedButtonGroup>
 
@@ -642,52 +641,52 @@
             android:layout_height="wrap_content"
             android:layout_gravity="center"
             android:layout_margin="4dp"
-            app:radius="30dp"
-            app:selectedButtonRadius="30dp"
-            app:selectedBackground="@color/blue_500"
-            app:draggable="true"
-            app:ripple="true"
-            app:rippleColor="@color/blue_500">
+            app:sbg_radius="30dp"
+            app:sbg_selectedButtonRadius="30dp"
+            app:sbg_selectedBackground="@color/blue_500"
+            app:sbg_draggable="true"
+            app:sbg_ripple="true"
+            app:sbg_rippleColor="@color/blue_500">
 
             <com.addisonelliott.segmentedbutton.SegmentedButton
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:padding="8dp"
-                app:rounded="true"
-                app:selectedTextColor="@color/white"
-                app:text="Button"
-                app:textColor="@color/black"
-                app:textSize="20sp" />
+                app:sb_rounded="true"
+                app:sb_selectedTextColor="@color/white"
+                app:sb_text="Button"
+                app:sb_textColor="@color/black"
+                app:sb_textSize="20sp" />
 
             <com.addisonelliott.segmentedbutton.SegmentedButton
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:padding="8dp"
-                app:rounded="true"
-                app:selectedTextColor="@color/white"
-                app:text="Button 2"
-                app:textColor="@color/black"
-                app:textSize="20sp" />
+                app:sb_rounded="true"
+                app:sb_selectedTextColor="@color/white"
+                app:sb_text="Button 2"
+                app:sb_textColor="@color/black"
+                app:sb_textSize="20sp" />
 
             <com.addisonelliott.segmentedbutton.SegmentedButton
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:padding="8dp"
-                app:rounded="true"
-                app:selectedTextColor="@color/white"
-                app:text="Button 3"
-                app:textColor="@color/black"
-                app:textSize="20sp" />
+                app:sb_rounded="true"
+                app:sb_selectedTextColor="@color/white"
+                app:sb_text="Button 3"
+                app:sb_textColor="@color/black"
+                app:sb_textSize="20sp" />
 
             <com.addisonelliott.segmentedbutton.SegmentedButton
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:padding="8dp"
-                app:rounded="true"
-                app:selectedTextColor="@color/white"
-                app:text="Button 4"
-                app:textColor="@color/black"
-                app:textSize="20sp" />
+                app:sb_rounded="true"
+                app:sb_selectedTextColor="@color/white"
+                app:sb_text="Button 4"
+                app:sb_textColor="@color/black"
+                app:sb_textSize="20sp" />
 
         </com.addisonelliott.segmentedbutton.SegmentedButtonGroup>
 
@@ -700,62 +699,58 @@
             android:layout_marginRight="4dp"
             android:layout_marginBottom="6dp"
             android:weightSum="3"
-            app:draggable="true"
-            app:selectedBackground="@color/indigo_800"
-            app:borderWidth="1dp"
-            app:borderColor="@color/indigo_800"
-            app:radius="12dp"
-            app:ripple="true"
-            app:rippleColor="@color/indigo_800"
-            >
+            app:sbg_borderColor="@color/indigo_800"
+            app:sbg_borderWidth="1dp"
+            app:sbg_draggable="true"
+            app:sbg_radius="12dp"
+            app:sbg_ripple="true"
+            app:sbg_rippleColor="@color/indigo_800"
+            app:sbg_selectedBackground="@color/indigo_800">
 
             <com.addisonelliott.segmentedbutton.SegmentedButton
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_weight="1"
                 android:padding="10dp"
-                app:textColor="@color/indigo_800"
-                app:selectedTextColor="@color/white"
-                app:text="Bar"
-                app:textSize="18sp"
-                app:drawable="@drawable/ic_chart_bar"
-                app:drawableTint="@color/indigo_800"
-                app:selectedDrawableTint="@color/white"
-                app:drawableGravity="top"
-                app:drawablePadding="4dp"
-                />
+                app:sb_drawable="@drawable/ic_chart_bar"
+                app:sb_drawableGravity="top"
+                app:sb_drawablePadding="4dp"
+                app:sb_drawableTint="@color/indigo_800"
+                app:sb_selectedDrawableTint="@color/white"
+                app:sb_selectedTextColor="@color/white"
+                app:sb_text="Bar"
+                app:sb_textColor="@color/indigo_800"
+                app:sb_textSize="18sp" />
 
             <com.addisonelliott.segmentedbutton.SegmentedButton
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_weight="1"
                 android:padding="10dp"
-                app:textColor="@color/indigo_800"
-                app:selectedTextColor="@color/white"
-                app:text="Pie"
-                app:textSize="18sp"
-                app:drawable="@drawable/ic_chart_pie"
-                app:drawableTint="@color/indigo_800"
-                app:selectedDrawableTint="@color/white"
-                app:drawableGravity="top"
-                app:drawablePadding="4dp"
-                />
+                app:sb_drawable="@drawable/ic_chart_pie"
+                app:sb_drawableGravity="top"
+                app:sb_drawablePadding="4dp"
+                app:sb_drawableTint="@color/indigo_800"
+                app:sb_selectedDrawableTint="@color/white"
+                app:sb_selectedTextColor="@color/white"
+                app:sb_text="Pie"
+                app:sb_textColor="@color/indigo_800"
+                app:sb_textSize="18sp" />
 
             <com.addisonelliott.segmentedbutton.SegmentedButton
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_weight="1"
                 android:padding="10dp"
-                app:textColor="@color/indigo_800"
-                app:selectedTextColor="@color/white"
-                app:text="Donut"
-                app:textSize="18sp"
-                app:drawable="@drawable/ic_chart_donut"
-                app:drawableTint="@color/indigo_800"
-                app:selectedDrawableTint="@color/white"
-                app:drawableGravity="top"
-                app:drawablePadding="4dp"
-                />
+                app:sb_drawable="@drawable/ic_chart_donut"
+                app:sb_drawableGravity="top"
+                app:sb_drawablePadding="4dp"
+                app:sb_drawableTint="@color/indigo_800"
+                app:sb_selectedDrawableTint="@color/white"
+                app:sb_selectedTextColor="@color/white"
+                app:sb_text="Donut"
+                app:sb_textColor="@color/indigo_800"
+                app:sb_textSize="18sp" />
 
         </com.addisonelliott.segmentedbutton.SegmentedButtonGroup>
     </LinearLayout>


### PR DESCRIPTION
This is a constant problem in Android. Attributes do not have name spaces. Attributes of the same name must have the same type. To make this library bulletproof and to avoid possible conflicts with other libraries `sb_` and `sbg_` prefixes were added. That approach was used in the original library.